### PR TITLE
Use githubs api instead of scraping

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,7 @@
-"ghprojects" is a half-baked program to scrape
-https://github.com/languages/Common%20Lisp/created and produce an Atom
-feed. It was written hastily and without didactic value in mind.
+"ghprojects" is a half-baked program to consume github's api, e.g.
+https://api.github.com/search/repositories?q=language:lisp+created:2013-11-02
+and produce an Atom feed. It was written hastily and without didactic
+value in mind.
 
 It is available under an MIT-style license. See the file LICENSE.txt
 for details.

--- a/atom-template.xml
+++ b/atom-template.xml
@@ -8,7 +8,7 @@
   <author>
    <name><!-- TMPL_VAR owner --></name>
   </author>
-  <link href="https://github.com<!-- TMPL_VAR path -->" />
+  <link href="<!-- TMPL_VAR path -->" />
   <id>urn:xach:github:<!-- TMPL_VAR owner -->:<!-- TMPL_VAR title --></id>
   <published><!-- TMPL_VAR date --></published>
   <updated><!-- TMPL_VAR date --></updated>

--- a/ghprojects.asd
+++ b/ghprojects.asd
@@ -4,10 +4,11 @@
   :serial t
   :description "Scrape GitHub and write out a feed for new Common Lisp
   projects."
-  :depends-on (#:webscraper
+  :depends-on (#:drakma
+               #:yason
+               #:flexi-streams
                #:html-template
-               #:cl-ppcre
-               #:closure-html)
+               #:cl-ppcre)
   :components ((:file "package")
                (:file "ghprojects")))
 

--- a/package.lisp
+++ b/package.lisp
@@ -1,7 +1,6 @@
 ;;;; package.lisp
 
 (defpackage #:ghprojects
-  (:use #:cl
-        #:webscraper)
+  (:use #:cl)
   (:export #:main))
 


### PR DESCRIPTION
Hopefully this will address issue #1.

I initially tried to get this working with minimal changes, using the link provided in the issue. The new search page places the creation date of the projects in an HTML5 element, and CHTML ignores HTML5 elements. While I was looking for a solution for that I found out that github search has an API. This patch takes advantage of the API instead of scraping with CHTML. 

Calling MAIN now creates the feed file for projects created the on same day or on the previous day.
